### PR TITLE
Downgrade cmake minimum version; Added /build and Makefiles to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build
+Makefile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.10)
 project(masterOptions)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")

--- a/src/masterd/CMakeLists.txt
+++ b/src/masterd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.10)
 project(masterd)
 
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
Ubuntu 18.04 LTS still uses cmake 3.10.2 in its repos, keeping the lists at a lower version makes the life of devs a little easier.
Build related files were added to the .gitignore so that building does not get in the way of versioning.