### PR TITLE
Fix for memory leaks in DeviceFinder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build
+Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 Makefile
+*~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.10)
 project(masterOptions)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")

--- a/src/masterd/CMakeLists.txt
+++ b/src/masterd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.10)
 project(masterd)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/src/masterd/DeviceFinder.h
+++ b/src/masterd/DeviceFinder.h
@@ -1,16 +1,25 @@
 #ifndef MASTEROPTIONS_DEVICEFINDER_H
 #define MASTEROPTIONS_DEVICEFINDER_H
 
+#include <hid/DeviceMonitor.h>
+#include "DeviceHandler.h"
+
 #define DEVICE_NAME "MX Master"
 
-struct handler_pair;
+struct handler_pair
+{
+    DeviceHandler* handler;
+    std::future<void> future;
+};
 
 class DeviceFinder : public HID::DeviceMonitor
 {
 protected:
     void addDevice(const char* path);
     void removeDevice(const char* path);
-    std::vector<handler_pair*> handlers;
+    std::vector<handler_pair> handlers;
+public:
+	~DeviceFinder(void);
 };
 
 void find_device();


### PR DESCRIPTION
Objects were instantiated with "new" but never destroyed with "delete". This problem is also present in other places in the code. 