### PR TITLE
Fix memory leaks in DeviceHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build
+Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 Makefile
+*~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.10)
 project(masterOptions)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")

--- a/src/masterd/CMakeLists.txt
+++ b/src/masterd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.10)
 project(masterd)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/src/masterd/DeviceHandler.cpp
+++ b/src/masterd/DeviceHandler.cpp
@@ -20,12 +20,12 @@ void DeviceHandler::start()
 {
     while(SCANNING_DEVICE) {}
 
-    const device* dev = new device {path.c_str(), index};
+    const device dev({path.c_str(), index});
 
-    apply_config(dev);
+    apply_config(&dev);
 
-    auto listener = new ListenerThread(dev);
-    auto listener_future = std::async(std::launch::async, &ListenerThread::listen, listener);
+    ListenerThread listener(&dev);
+    auto listener_future = std::async(std::launch::async, &ListenerThread::listen, &listener);
 
     HIDPP::SimpleDispatcher dispatcher(path.c_str());
     HIDPP20::Device d(&dispatcher, index);
@@ -57,7 +57,7 @@ void DeviceHandler::start()
             {
                 try
                 {
-                    apply_config(dev);
+                    apply_config(&dev);
                     break;
                 }
                 catch(std::exception e) {}
@@ -67,6 +67,6 @@ void DeviceHandler::start()
         usleep(200000);
     }
 
-    listener->stop();
+    listener.stop();
     listener_future.wait();
 }


### PR DESCRIPTION
Objects were instantiated with "new" but never destroyed with "delete". This problem is also present in other places in the code.